### PR TITLE
fix: replace mobilenet_v3_small with resnet50 as default classifier

### DIFF
--- a/ML_MODEL.md
+++ b/ML_MODEL.md
@@ -1,9 +1,21 @@
 ## ML Model and Weights
 
 The ML model comes from `torchvision` and is loaded with pretrained weights at app startup.
-Specifically, in `src/model/infer.py` the default `torchvision` weights are used:
-- Person detector (Faster R-CNN): `models.detection.fasterrcnn_resnet50_fpn(weights=FasterRCNN_ResNet50_FPN_Weights.DEFAULT)`
-- Classifier: `models.mobilenet_v3_small(weights=MobileNet_V3_Small_Weights.DEFAULT)`
+In `src/model/infer.py` the default `torchvision` weights are used:
+
+### Classifier models (ImageNet-1K, 1000 classes)
+
+| Model | `model_name` | Top-1 Accuracy | Params | Notes |
+|-------|-------------|----------------|--------|-------|
+| ResNet-50 | `resnet50` | ~80.9% | 25M | **Default.** Best accuracy, recommended for production |
+| EfficientNet-B0 | `efficientnet_b0` | ~77.7% | 5.3M | Good balance of accuracy and speed |
+| MobileNetV3-Small | `mobilenet_v3_small` | ~67.7% | 2.5M | Fastest, but weakest accuracy — not recommended for general classification |
+
+### Detector models
+
+| Model | `model_name` | Notes |
+|-------|-------------|-------|
+| Faster R-CNN (ResNet-50 FPN) | `person_detector` | Returns only `person` / `no_person` |
 
 These weights are downloaded automatically on first run and cached by PyTorch
 (typically `~/.cache/torch/hub/checkpoints`; on Windows `C:\Users\<user>\AppData\Local\...`).
@@ -15,14 +27,12 @@ The core libraries are installed from `requirements.txt`:
 ## ML Model and Device Selection
 
 Model selection and device are controlled by settings in `src/config.py`:
-- `model_name`
-- `device`
+- `model_name` — which model to load (see table above)
+- `device` — `cpu` or `cuda`
 
 Defaults:
+- `model_name: resnet50`
 - `device: cpu`
-- In `config.example.yaml`:
-  - `model_name: person_detector`
-  - `device: cpu`
 
 On API startup this configuration is loaded and logged in `src/api/app.py`
 (`load_settings()` → `load_model()`).
@@ -30,15 +40,24 @@ On API startup this configuration is loaded and logged in `src/api/app.py`
 ## How to Change the ML Model or Device
 
 YAML config:
-- `model_name: person_detector` or `mobilenet_v3_small`
+- `model_name: resnet50` (recommended) or `efficientnet_b0`, `mobilenet_v3_small`, `person_detector`
 - `device: cuda` (only if CUDA is available)
 
 Environment variables:
-- `APP_MODEL_NAME=person_detector`
+- `APP_MODEL_NAME=resnet50`
 - `APP_DEVICE=cuda`
+
+## Why ResNet-50 is the Default
+
+MobileNetV3-Small was previously the default, but its low accuracy (~67.7%) caused
+incorrect predictions on many real-world images (e.g., trees classified as "jigsaw puzzle",
+people misclassified). ResNet-50 provides significantly better accuracy (~80.9%) while
+still being fast enough for real-time inference on CPU.
 
 ## Useful Notes
 
 - When using the detector, predictions are a simple person/no_person result based on
   `person_score_threshold` from config.
 - If the weights are already cached, startup is faster and no download occurs.
+- ImageNet does not have a generic "tree" class — it has specific tree species and
+  scene categories. The classifier will return the closest matching ImageNet category.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,7 +8,15 @@ frame_sample_fps: 2
 frame_width: 640
 frame_height: 360
 #camera_name: USB Video Device
-model_name: mobilenet_v3_small
+# Classifier models (ImageNet-1K, 1000 classes):
+#   resnet50           - best accuracy (~80.9% top-1), ~25M params, recommended
+#   efficientnet_b0    - good accuracy (~77.7% top-1), ~5.3M params, lighter
+#   mobilenet_v3_small - fastest but weakest (~67.7% top-1), ~2.5M params
+# Detector models:
+#   person_detector    - Faster R-CNN, person/no_person only
+model_name: resnet50
+#model_name: efficientnet_b0
+#model_name: mobilenet_v3_small
 #model_name: person_detector
 device: cpu
 metrics_log_every: 50

--- a/src/config.py
+++ b/src/config.py
@@ -16,7 +16,7 @@ class Settings(BaseSettings):
     frame_sample_fps: int = 2
     frame_width: int = 640
     frame_height: int = 360
-    model_name: str = "mobilenet_v3_small"
+    model_name: str = "resnet50"
     device: str = "cpu"
     metrics_log_every: int = 50
     save_processed: bool = False

--- a/src/model/infer.py
+++ b/src/model/infer.py
@@ -1,15 +1,38 @@
 from __future__ import annotations
 
+import logging
 from typing import List, Tuple
 
 import torch
 from PIL import Image
 from torchvision import models
-from torchvision.models import MobileNet_V3_Small_Weights
+from torchvision.models import (
+    EfficientNet_B0_Weights,
+    MobileNet_V3_Small_Weights,
+    ResNet50_Weights,
+)
 from torchvision.models.detection import FasterRCNN_ResNet50_FPN_Weights
 
 from src.config import Settings
 from src.preprocess.transforms import to_pil
+
+logger = logging.getLogger(__name__)
+
+# Supported classifier models and their loaders
+_CLASSIFIER_REGISTRY: dict[str, tuple] = {
+    "resnet50": (
+        lambda: models.resnet50(weights=ResNet50_Weights.DEFAULT),
+        ResNet50_Weights.DEFAULT,
+    ),
+    "efficientnet_b0": (
+        lambda: models.efficientnet_b0(weights=EfficientNet_B0_Weights.DEFAULT),
+        EfficientNet_B0_Weights.DEFAULT,
+    ),
+    "mobilenet_v3_small": (
+        lambda: models.mobilenet_v3_small(weights=MobileNet_V3_Small_Weights.DEFAULT),
+        MobileNet_V3_Small_Weights.DEFAULT,
+    ),
+}
 
 
 def load_model(
@@ -22,9 +45,26 @@ def load_model(
         categories = list(weights.meta.get("categories", []))
         preprocess = weights.transforms()
         model_kind = "detector"
+    elif settings.model_name in _CLASSIFIER_REGISTRY:
+        model_factory, weights = _CLASSIFIER_REGISTRY[settings.model_name]
+        model = model_factory()
+        categories = list(weights.meta.get("categories", []))
+        preprocess = weights.transforms()
+        model_kind = "classifier"
+        logger.info(
+            "Loaded classifier model=%s  categories=%d  top1_acc=%.1f%%",
+            settings.model_name,
+            len(categories),
+            weights.meta.get("_metrics", {}).get("ImageNet-1K", {}).get("acc@1", 0),
+        )
     else:
-        weights = MobileNet_V3_Small_Weights.DEFAULT
-        model = models.mobilenet_v3_small(weights=weights)
+        # Fallback: treat unknown name as mobilenet_v3_small for backward compat
+        logger.warning(
+            "Unknown model_name=%s, falling back to resnet50",
+            settings.model_name,
+        )
+        weights = ResNet50_Weights.DEFAULT
+        model = models.resnet50(weights=weights)
         categories = list(weights.meta.get("categories", []))
         preprocess = weights.transforms()
         model_kind = "classifier"

--- a/tests/test_infer.py
+++ b/tests/test_infer.py
@@ -191,3 +191,90 @@ def test_predict_different_image_sizes(mobilenet_settings):
         )
         assert len(results) == 3
         assert all("label" in r and "score" in r for r in results)
+
+
+# --- Tests for additional classifier models ---
+
+
+@pytest.fixture
+def resnet50_settings():
+    """Settings for ResNet-50 model."""
+    return Settings(
+        model_name="resnet50",
+        device="cpu",
+        class_topk=5,
+    )
+
+
+@pytest.fixture
+def efficientnet_settings():
+    """Settings for EfficientNet-B0 model."""
+    return Settings(
+        model_name="efficientnet_b0",
+        device="cpu",
+        class_topk=5,
+    )
+
+
+def test_load_model_resnet50(resnet50_settings):
+    """Smoke test: Load ResNet-50 model."""
+    model, preprocess, categories, device, model_kind = load_model(resnet50_settings)
+
+    assert model is not None
+    assert preprocess is not None
+    assert len(categories) == 1000  # ImageNet classes
+    assert device.type == "cpu"
+    assert model_kind == "classifier"
+
+
+def test_predict_pil_resnet50(resnet50_settings):
+    """Smoke test: Run inference with ResNet-50 on PIL image."""
+    model, preprocess, categories, device, model_kind = load_model(resnet50_settings)
+    image = _create_test_image()
+
+    results = predict_pil(
+        model, preprocess, categories, device, image,
+        topk=5, model_kind=model_kind,
+    )
+
+    assert isinstance(results, list)
+    assert len(results) == 5
+    assert all("label" in r and "score" in r for r in results)
+    assert all(0.0 <= r["score"] <= 1.0 for r in results)
+
+
+def test_load_model_efficientnet(efficientnet_settings):
+    """Smoke test: Load EfficientNet-B0 model."""
+    model, preprocess, categories, device, model_kind = load_model(efficientnet_settings)
+
+    assert model is not None
+    assert preprocess is not None
+    assert len(categories) == 1000
+    assert device.type == "cpu"
+    assert model_kind == "classifier"
+
+
+def test_predict_pil_efficientnet(efficientnet_settings):
+    """Smoke test: Run inference with EfficientNet-B0 on PIL image."""
+    model, preprocess, categories, device, model_kind = load_model(efficientnet_settings)
+    image = _create_test_image()
+
+    results = predict_pil(
+        model, preprocess, categories, device, image,
+        topk=5, model_kind=model_kind,
+    )
+
+    assert isinstance(results, list)
+    assert len(results) == 5
+    assert all("label" in r and "score" in r for r in results)
+    assert all(0.0 <= r["score"] <= 1.0 for r in results)
+
+
+def test_load_model_unknown_falls_back_to_resnet50():
+    """Unknown model_name should fall back to resnet50."""
+    settings = Settings(model_name="nonexistent_model", device="cpu")
+    model, preprocess, categories, device, model_kind = load_model(settings)
+
+    assert model is not None
+    assert len(categories) == 1000
+    assert model_kind == "classifier"


### PR DESCRIPTION
MobileNetV3-Small (~67.7% top-1 accuracy) produced incorrect predictions on real-world images (e.g. tree → "jigsaw puzzle", tree photo → "lakeside").

Changes:
- Add classifier model registry with resnet50, efficientnet_b0, mobilenet_v3_small
- Set resnet50 (~80.9% top-1) as default model_name in config
- Unknown model_name now falls back to resnet50 with a warning
- Add smoke tests for resnet50, efficientnet_b0, and fallback behavior
- Update config.example.yaml with model comparison comments
- Update ML_MODEL.md with model accuracy table and migration notes